### PR TITLE
feat: add support for fiat currency options

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,3 +10,16 @@ export const appCustomDataValues = {
 
 // https://bitcoin.stackexchange.com/questions/85951/whats-the-maximum-size-of-the-memo-in-a-ln-payment-request
 export const MAX_MEMO_LENGTH = 159;
+
+export const CURRENCIES = [
+  { currency: "USD", country: "us" },
+  { currency: "GBP", country: "gb" },
+  { currency: "EUR", country: "eu" },
+  { currency: "CAD", country: "ca" },
+  { currency: "JPY", country: "jp" },
+  { currency: "AUD", country: "au" }, 
+  { currency: "CHF", country: "ch" },
+  { currency: "CNY", country: "cn" },
+  { currency: "HKD", country: "hk" },
+  { currency: "NZD", country: "nz" }
+];


### PR DESCRIPTION
### What type of PR is this? (check all applicable)

- [ ]  ♻️ Refactor
- [x]  ✨ New Feature
- [ ]  🐛 Bug Fix
- [ ]  📝 Documentation Update
- [ ]  👷 Example Application
- [ ]  🧑‍💻 Code Snippet
- [ ]  🎨 Design
- [ ]  📖 Content
- [ ]  🧪 Tests
- [ ]  🔖 Release
- [ ]  🚩 Other


### Description
This PR implements a select option for users to choose the currency they would like to pay in. It supports users paying with USD, GBP, EUR e.t.c and then converts the amount to its equivalent value in sats using Alby's Js-lightning-tool fiat getSatoshiValue method. 

### Related Tickets & Documents
Resolves https://github.com/getAlby/pos/issues/4

### Video Demo:

https://github.com/user-attachments/assets/d6c062f2-2f9e-4da3-aaa6-7918c874afc2


